### PR TITLE
强迫症速效治疗，修复Issue#5以及更多UI问题

### DIFF
--- a/PrincessAdventure/static/yocool/css/style.css
+++ b/PrincessAdventure/static/yocool/css/style.css
@@ -847,3 +847,7 @@ td {
 .el-notification__title {
 	color: var(--font-color);
 }
+
+.el-tabs__item{
+	width: 40%;
+}

--- a/PrincessAdventure/template/clan/panel.html
+++ b/PrincessAdventure/template/clan/panel.html
@@ -40,7 +40,7 @@
 		<div class="clanname">[[groupData.group_name]]</div>
 		<el-container style="margin-top: 0px;">
 			<el-main style="padding: 0 5%">
-				<el-row class="clanbg" style="margin-bottom: -16%;">
+				<el-row class="clanbg" style="margin-bottom: -10%;">
 					<el-col :span="12"><span class="exxbig" style="line-height: 120px;">[[ bossData.cycle ]]</span><span class="exbig">周目</span></el-col>
 					<el-col :span="12"><span class="exxbig" style="line-height: 120px;">[[ bossData.num ]]</span><span class="exbig">号boss</span></el-col>
 				</el-row>

--- a/PrincessAdventure/template/clan/progress.html
+++ b/PrincessAdventure/template/clan/progress.html
@@ -108,7 +108,7 @@
 		</el-dialog>
 		<template v-if="progressData.length > 0">
 			<el-button class="progress-btn" type="primary" @click="viewTails">尾刀一览</el-button>
-			<el-row style="margin: 5px 0px 15px">
+			<el-row class='el-table' style="margin: auto;padding-bottom: 2%;">
 				<el-col style="display: flex; justify-content: space-between; margin-bottom: 5px;">
 					<div>
 						<p>成员[[ members.length ]]，已出[[ progressData.reduce((s,i)=>s+i.finished,0) ]]，剩余[[ members.length *

--- a/PrincessAdventure/template/clan/subscribers.html
+++ b/PrincessAdventure/template/clan/subscribers.html
@@ -31,7 +31,7 @@
         	</el-menu>
         </div>
         <h1 style="text-align:center">预约名单</h1>
-        <el-tabs type="border-card">
+        <el-tabs type="border-card" style="width: 90%;margin: auto;">
             <el-tab-pane v-for="bn in 6">
                 <span slot="label">
                     <el-badge :value="subscribers[bn-1].length" :hidden="subscribers[bn-1].length == 0">[[ bosstag[bn-1] ]]</el-badge>


### PR DESCRIPTION
修复#5 
1.修复公会面板在高分屏下的显示问题
2.对齐查刀页面那根超长进度条和table，现在那根进度条和table一样长而不是撑满整个页面
3.预约页面的tab太小了，还是原来的样式，顺手改大了点
4.预约页面整个框体撑满不好看，顺手width改了一下
5.多个公会显示要用的话我想还是自己改吧，就不merge了，确实一个我的公会按钮比较好，我有多个工会属于特殊情况。。。